### PR TITLE
Correct decoNote for MS. Canon. Or. 81.

### DIFF
--- a/collections/MS_Canonici_Or_81.xml
+++ b/collections/MS_Canonici_Or_81.xml
@@ -76,7 +76,7 @@
                      <handNote scope="sole" script="sephardi" rend="semi-cursive"/>
                   </handDesc>
                   <decoDesc>
-                     <decoNote>Not decorated.</decoNote>
+                     <decoNote>Illuminations.</decoNote>
                   </decoDesc>
                   <bindingDesc>
                      <p>Brown leather binding, blind-tooled.</p>


### PR DESCRIPTION
The Neubauer entry says "Illuminations." And there are quite a few: https://digital.bodleian.ox.ac.uk/inquire/p/9afcbe2a-bc4d-4d37-af7e-6b91653d81d2