### PR TITLE
display former shelfmarks and neubauer numbers

### DIFF
--- a/processing/convert2HTML.xsl
+++ b/processing/convert2HTML.xsl
@@ -136,7 +136,20 @@
             </div>
         </xsl:if>
     </xsl:template>
-
+    <xsl:template match="msDesc/msIdentifier/altIdentifier[@type='former' and child::idno[not(@subtype)]]">
+        <p>
+            <xsl:text>Former shelfmark: </xsl:text>
+            <xsl:apply-templates/>
+        </p>
+    </xsl:template>
+    
+    <xsl:template match="msDesc/msIdentifier/altIdentifier[@type='other' and child::idno[@type='Neubauer']]">
+        <p>
+            <xsl:text>Neubauer no: </xsl:text>
+            <xsl:apply-templates/>
+        </p>
+    </xsl:template>
+    
     <!-- Override function of bod:direction - Rails now strips style attributes.  TODO move to lib/msdesc2html.xsl -->
     <xsl:function name="bod:rtl" as="attribute()?">
         <xsl:param name="elem" as="element()?"/>


### PR DESCRIPTION
This pull request displays former shelfmarks and 'Neubauer' numbers, which remain one of the key ways that the Hebrew manuscripts are organised. 